### PR TITLE
Add additional usage info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,47 @@ Boot task for running jUnit Java tests.
 First, make sure the root of your java sources and test sources are
 included in your boot `:source-paths`:
 
-    (set-env!
-     :source-paths #{"src/main/java" "src/test/java"}
-     ...)
+```clojure
+(set-env!
+  :source-paths #{"src/main/java" "src/test/java"}
+  ...)
+```
+
+If JUnit is not already included as a dependency, you will need to include it. Maven dependency information for JUnit4 can be found [here](https://github.com/junit-team/junit4/wiki/Use-with-Maven). Then, you can then do something like this in your build.boot:
+
+```clojure
+(set-env!
+  ...
+  :dependencies [junit/junit              "4.12"  :scope "test"]
+                [radicalzephyr/boot-junit "0.2.1" :scope "test"]
+  ...)
+```
+
+To make the `junit` task available in your Boot task pipeline:
+
+```clojure
+(require '[radicalzephyr.boot-junit :refer (junit)])
+```
 
 Optionally, you can configure the `junit` task with the packages to be
 searched for jUnit tests.
 
-    (task-options!
-     junit {:packages '#{radicalzephyr.boot_junit.test}})
+```clojure
+(task-options!
+  junit {:packages '#{radicalzephyr.boot_junit.test}})
+```
 
 If no packages are specified, the task will automatically try to run
 all tests in packages defined in the current project.
 
 Finally, I typically define a `test` task for ease of use.
 
-    (deftask test
-      "Compile and run my jUnit tests."
-      []
-      (comp (javac)
-            (junit)))
+```clojure
+(deftask test
+  "Compile and run my jUnit tests."
+  []
+  (comp (javac)
+        (junit)))
+```
 
 Now just run `boot test`!


### PR DESCRIPTION
Thanks for boot-junit, it works like a charm!

There were a couple of additional steps I needed to take to get my JUnit tests to run -- this PR adds some additional usage instructions to the README.